### PR TITLE
Update currentRule when changing active pluralExtension

### DIFF
--- a/lib/tap_i18next/tap_i18next-1.7.3.js
+++ b/lib/tap_i18next/tap_i18next-1.7.3.js
@@ -2540,7 +2540,12 @@ TAPi18next = {};
     
         // for demonstration only sl and ar is added but you can add your own pluralExtensions
         addRule: function(lng, obj) {
-            pluralExtensions.rules[lng] = obj;    
+            pluralExtensions.rules[lng] = obj;
+            
+            if(pluralExtensions.currentRule && pluralExtensions.currentRule.lng === lng) {
+                pluralExtensions.currentRule.lng = '';
+                pluralExtensions.setCurrentLng(lng);
+            }
         },
     
         setCurrentLng: function(lng) {


### PR DESCRIPTION
When using addRule, currentRule stays unmodified, so the new rule is not active.

Calling setCurrentLng also did not help, because the language does not change,
and currentRule is already defined.

With this patch, when you addRule it checks if you are modifying the current language.
If it's the case, it clears the currentRule.lng  and calls setCurrentLng.

I'm not sure if this is the best approach. Another approach would be to set currentRule to false
and call setCurrentLng(). Or avoid this change altogether and let people delete the currentRule themselves?
But that would mean 3 steps: addRule(..), currentRule = false, setCurrentLng(..).
