### PR TITLE
Compiler: correction output path

### DIFF
--- a/lib/plugin/compilers/i18n.json.coffee
+++ b/lib/plugin/compilers/i18n.json.coffee
@@ -115,7 +115,7 @@ Plugin.registerSourceHandler "i18n.json", (compileStep) ->
         """
       compiler_configuration.templates_registered_for.push helpers.getCompileStepArchAndPackage(compileStep)
 
-  output_path = input_path.replace /json$/, "js"
+  output_path = compileStep.rootOutputPath + compileStep.inputPath.replace /json$/, "js"
   compileStep.addJavaScript
     path: output_path,
     sourcePath: input_path,


### PR DESCRIPTION
The path of the compiled *.i18n.json contains the whole os path, including (in linux) the user folder and the project folder. This differs from normal behavior in Meteor.

This correction set the path of the compiled json as it is given from the application.

This correction affects both the client as the server.

Example, paths in the browser source tree:
Before: ```/home/myuser/trash/test/i18n/en.i18n.js?a115d4ab93328ac005e5659985862a2b4fe9bd17```
After: ```/i18n/en.i18n.js?7c81469ac0c0264a6a7345a802e5821f0cd8c09b```