### PR TITLE
Removed deprecated aldeed:simple-schema

### DIFF
--- a/lib/plugin/compilers/package-tap.i18n.coffee
+++ b/lib/plugin/compilers/package-tap.i18n.coffee
@@ -1,6 +1,7 @@
 helpers = share.helpers
 compilers = share.compilers
 compiler_configuration = share.compiler_configuration
+SimpleSchema = Npm.require('simpl-schema').default
 
 schema = new SimpleSchema
   translation_function_name:

--- a/lib/plugin/compilers/project-tap.i18n.coffee
+++ b/lib/plugin/compilers/project-tap.i18n.coffee
@@ -1,6 +1,7 @@
 helpers = share.helpers
 compilers = share.compilers
 compiler_configuration = share.compiler_configuration
+SimpleSchema = Npm.require('simpl-schema').default
 
 share.project_i18n_schema = schema = new SimpleSchema
   helper_name:
@@ -9,7 +10,7 @@ share.project_i18n_schema = schema = new SimpleSchema
     label: "Helper Name"
     optional: true
   supported_languages:
-    type: [String]
+    type: Array
     label: "Supported Languages"
     defaultValue: null
     optional: true
@@ -19,7 +20,7 @@ share.project_i18n_schema = schema = new SimpleSchema
     defaultValue: globals.browser_path
     optional: true
   preloaded_langs:
-    type: [String]
+    type: Array
     label: "Preload languages"
     defaultValue: []
     optional: true
@@ -82,7 +83,7 @@ compilers.project_tap_i18n = (compileStep) ->
     check project_tap_i18n, schema
   catch error
     compileStep.error
-      message: "File `#{file_path}' is an invalid project-tap.i18n file (#{error})",
+      message: "project-tap.i18n file is invalid (#{error})",
       sourcePath: input_path
     return
 

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'tap:i18n',
   summary: 'A comprehensive internationalization solution for Meteor',
-  version: '1.8.1',
+  version: '1.8.2',
   git: 'https://github.com/TAPevents/tap-i18n'
 });
 
@@ -52,10 +52,11 @@ Package.onUse(function (api) {
 
 Package.registerBuildPlugin({
   name: 'tap-i18n-compiler',
-  use: ['coffeescript', 'underscore', 'aldeed:simple-schema@1.3.0', 'check@1.0.3', 'templating'],
+  use: ['coffeescript', 'underscore', 'check@1.0.3', 'templating'],
   npmDependencies: {
     "node-json-minify": "0.1.3-a",
-    "yamljs": "0.2.4"
+    "yamljs": "0.2.4",
+    "simpl-schema" : "0.2.3"
   },
   sources: [
     'lib/globals.js',


### PR DESCRIPTION
I had same issue #203 and removed deprecated package on my own.
I did it with little coffeescript knowledge which means I may have some mistakes and I also had to remove one variable from an error message, which I don't know why exactly, meteor compiler didn't let me pass otherwise.