### PR TITLE
Remove dependency to aldeed:simple-schema

### DIFF
--- a/lib/plugin/compilers/package-tap.i18n.coffee
+++ b/lib/plugin/compilers/package-tap.i18n.coffee
@@ -1,6 +1,7 @@
 helpers = share.helpers
 compilers = share.compilers
 compiler_configuration = share.compiler_configuration
+SimpleSchema = Npm.require('simpl-schema').default
 
 schema = new SimpleSchema
   translation_function_name:
@@ -50,10 +51,10 @@ compilers.package_tap_i18n = (compileStep) ->
   schema.clean package_tap_i18n
 
   try
-    check package_tap_i18n, schema
+    SimpleSchema.validate(package_tap_i18n, schema)
   catch error
     compileStep.error
-      message: "File `#{file_path}' is an invalid package-tap.i18n file (#{error})",
+      message: "File `#{input_path}' is an invalid package-tap.i18n file (#{error})",
       sourcePath: input_path
     return
 

--- a/lib/plugin/compilers/project-tap.i18n.coffee
+++ b/lib/plugin/compilers/project-tap.i18n.coffee
@@ -1,6 +1,7 @@
 helpers = share.helpers
 compilers = share.compilers
 compiler_configuration = share.compiler_configuration
+SimpleSchema = Npm.require('simpl-schema').default
 
 share.project_i18n_schema = schema = new SimpleSchema
   helper_name:
@@ -9,20 +10,24 @@ share.project_i18n_schema = schema = new SimpleSchema
     label: "Helper Name"
     optional: true
   supported_languages:
-    type: [String]
-    label: "Supported Languages"
+    type: Array
     defaultValue: null
     optional: true
+  "supported_languages.$":
+    type: String
+    label: "Supported Languages"
   i18n_files_route:
     type: String
     label: "Unified languages files path"
     defaultValue: globals.browser_path
     optional: true
   preloaded_langs:
-    type: [String]
-    label: "Preload languages"
-    defaultValue: []
+    type: Array
     optional: true
+    defaultValue: []
+  "preloaded_langs.$":
+    type: String
+    label: "Preload languages"
   cdn_path:
     type: String
     label: "Unified languages files path on CDN"
@@ -82,7 +87,7 @@ compilers.project_tap_i18n = (compileStep) ->
     check project_tap_i18n, schema
   catch error
     compileStep.error
-      message: "File `#{file_path}' is an invalid project-tap.i18n file (#{error})",
+      message: "File `#{input_path}' is an invalid project-tap.i18n file (#{error})",
       sourcePath: input_path
     return
 

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'tap:i18n',
   summary: 'A comprehensive internationalization solution for Meteor',
-  version: '1.8.1',
+  version: '1.8.2',
   git: 'https://github.com/TAPevents/tap-i18n'
 });
 
@@ -52,10 +52,11 @@ Package.onUse(function (api) {
 
 Package.registerBuildPlugin({
   name: 'tap-i18n-compiler',
-  use: ['coffeescript', 'underscore', 'aldeed:simple-schema@1.3.0', 'check@1.0.3', 'templating'],
+  use: ['coffeescript', 'underscore', 'templating'],
   npmDependencies: {
     "node-json-minify": "0.1.3-a",
-    "yamljs": "0.2.4"
+    "yamljs": "0.2.4",
+    "simpl-schema" : "0.2.3"
   },
   sources: [
     'lib/globals.js',


### PR DESCRIPTION
- Remove aldeed:simple-schema
- Add simpl-schema as npm dependency
- Fix a couple of quirks related to the new ss api
- Remove check package as no longer needed
- Fix a minor problem with file_path -> input_path

This is a small improvement on  #204 to fix #203 