### PR TITLE
Fix language tag regex to support script variants

### DIFF
--- a/lib/globals.js
+++ b/lib/globals.js
@@ -3,7 +3,7 @@
 
 globals = {
   fallback_language: "en",
-  langauges_tags_regex: "([a-z]{2})(-[A-Z]{2})?",
+  langauges_tags_regex: "([a-z]{2})(-[A-Z][a-z]{3})?(-[A-Z]{2})?",
   project_translations_domain: "project",
   browser_path: "/tap-i18n",
   debug: false


### PR DESCRIPTION
This is required to be able to support tag with script variants, such as zh-Hans