### PR TITLE
Fix use of deprecated API in package.js

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'tap:i18n',
   summary: 'A comprehensive internationalization solution for Meteor',
-  version: '1.8.1',
+  version: '1.8.2',
   git: 'https://github.com/TAPevents/tap-i18n'
 });
 
@@ -10,7 +10,7 @@ server = 'server';
 client = 'client';
 
 Package.onUse(function (api) {
-  api.versionsFrom('0.9.4');
+  api.versionsFrom('1.0.0');
 
   api.use('coffeescript', both);
   api.use('underscore', both);
@@ -27,25 +27,25 @@ Package.onUse(function (api) {
   api.use('cfs:http-methods@0.0.27', server);
 
   // load TAPi18n
-  api.add_files('lib/globals.js', both);
+  api.addFiles('lib/globals.js', both);
 
   // load and init TAPi18next
-  api.add_files('lib/tap_i18next/tap_i18next-1.7.3.js', both);
+  api.addFiles('lib/tap_i18next/tap_i18next-1.7.3.js', both);
   api.export('TAPi18next');
-  api.add_files('lib/tap_i18next/tap_i18next_init.js', both);
+  api.addFiles('lib/tap_i18next/tap_i18next_init.js', both);
 
-  api.add_files('lib/tap_i18n/tap_i18n-helpers.coffee', both);
+  api.addFiles('lib/tap_i18n/tap_i18n-helpers.coffee', both);
 
   // We use the bare option since we need TAPi18n in the package level and
   // coffee adds vars to all (so without bare all vars are in the file level)
-  api.add_files('lib/tap_i18n/tap_i18n-common.coffee', server);
-  api.add_files('lib/tap_i18n/tap_i18n-common.coffee', client, {bare: true});
+  api.addFiles('lib/tap_i18n/tap_i18n-common.coffee', server);
+  api.addFiles('lib/tap_i18n/tap_i18n-common.coffee', client, {bare: true});
 
-  api.add_files('lib/tap_i18n/tap_i18n-server.coffee', server);
-  api.add_files('lib/tap_i18n/tap_i18n-client.coffee', client, {bare: true});
+  api.addFiles('lib/tap_i18n/tap_i18n-server.coffee', server);
+  api.addFiles('lib/tap_i18n/tap_i18n-client.coffee', client, {bare: true});
 
-  api.add_files('lib/tap_i18n/tap_i18n-init.coffee', server);
-  api.add_files('lib/tap_i18n/tap_i18n-init.coffee', client, {bare: true});
+  api.addFiles('lib/tap_i18n/tap_i18n-init.coffee', server);
+  api.addFiles('lib/tap_i18n/tap_i18n-init.coffee', client, {bare: true});
 
   api.export('TAPi18n');
 });


### PR DESCRIPTION
Fixes use of deprecated API in `package.js` which has been finally removed in Meteor 2.3