### PR TITLE
Support setting preloaded_langs on the fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,10 +604,23 @@ project, will be available.
 **i18n\_files\_route:** The route in which the tap-i18n resources will be available in the project.
 
 **preloaded_langs:** An array of languages tags. If isn't empty, a single synchronous ajax requrest will load the translation strings for all the languages tags listed. If you want to load all the supported languages set preloaded_langs to `["*"]` (`"*"` must be the first item of the array, the rest of the array will be ignored. `["zh-*"]` won't work).
+An alernative way to dynamically set preloaded_langs on runtime is by defining the **TAP_I18N_PRELOADED_LANGS** global variable. This variable should be an array of language tags.
+```html
+<head>
+  <script>
+    TAP_I18N_PRELOADED_LANGS = ["pt-BR", "zh-TW", "he"];
+  </script>
+  <!-- ... other head elements ... -->
+  <script src="path/to/your/tapi18n/bundle.js"></script>
+</head>
+```
+
 
 **Notes:**
 
+* English is loaded by default, so you don't need to include it in the preloaded language list.
 * We use AJAX to load the languages files so you'll have to set CORS on your CDN.
+*  Support of TAP_I18N_PRELOADED_LANGS relies on the `project-tap.i18n` build plugin. In other words, if `project-tap.i18n` doesn't exist, TAP_I18N_PRELOADED_LANGS will have **no** effect.
 
 ### Configuring CDN in tap-i18n
 

--- a/lib/plugin/compilers/project-tap.i18n.coffee
+++ b/lib/plugin/compilers/project-tap.i18n.coffee
@@ -83,26 +83,34 @@ compilers.project_tap_i18n = (compileStep) ->
 
   project_i18n_js_file = getProjectConfJs project_tap_i18n
 
-  if compileStep.archMatches("web") and not _.isEmpty project_tap_i18n.preloaded_langs
+  if compileStep.archMatches("web")
     preloaded_langs = "all"
     if project_tap_i18n.preloaded_langs[0] != "*"
-      preloaded_langs = project_tap_i18n.preloaded_langs.join(",")
+      preloaded_langs = project_tap_i18n.preloaded_langs
 
     project_i18n_js_file +=
       """
-      $.ajax({
-          type: 'GET',
-          url: TAPi18n._cdn("#{project_tap_i18n.i18n_files_route}/multi/#{preloaded_langs}.json"),
-          dataType: 'json',
-          success: function(data) {
-            for (lang_tag in data) {
-              TAPi18n._loadLangFileObject(lang_tag, data[lang_tag]);
-              TAPi18n._loaded_languages.push(lang_tag);
-            }
-          },
-          data: {},
-          async: false
-      });
+      let preloaded_langs = #{JSON.stringify preloaded_langs};
+
+      if (preloaded_langs !== "all" && (typeof TAP_I18N_PRELOADED_LANGS !== "undefined" && TAP_I18N_PRELOADED_LANGS !== null)) {
+          preloaded_langs = _.union(preloaded_langs, TAP_I18N_PRELOADED_LANGS).join(",");
+        }
+
+      if (!_.isEmpty(preloaded_langs)) {
+        $.ajax({
+            type: 'GET',
+            url: TAPi18n._cdn(`#{project_tap_i18n.i18n_files_route}/multi/${preloaded_langs}.json`),
+            dataType: 'json',
+            success: function(data) {
+              for (lang_tag in data) {
+                TAPi18n._loadLangFileObject(lang_tag, data[lang_tag]);
+                TAPi18n._loaded_languages.push(lang_tag);
+              }
+            },
+            data: {},
+            async: false
+        });
+      }
 
       """
 


### PR DESCRIPTION
On top of existing preloaded_langs in project-tap.i18n, allow controlling the list of preloaded langs with global variable TAP_I18N_PRELOADED_LANGS