### PR TITLE
Remove tj (correct lang tag should be tg)

### DIFF
--- a/lib/plugin/etc/language_names.js
+++ b/lib/plugin/etc/language_names.js
@@ -118,7 +118,6 @@ language_names = {
   "sw": ["Swahili","Kiswahili"],
   "sv": ["Swedish","Svenska"],
   "gsw": ["Swiss German","Schwyzerdütsch"],
-  "tj": ["Tajik","тоҷикӣ"],
   "tl": ["Tagalog","Tagalog"],
   "tg": ["Tajik","тоҷикӣ"],
   "ta": ["Tamil","தமிழ்"],


### PR DESCRIPTION
As per [https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes), lang code for Tajik is tg, which is already there.