### PR TITLE
Plugin.registerSourceHandler > Plugin.registerCompiler 

### DIFF
--- a/lib/plugin/compiler_configuration.coffee
+++ b/lib/plugin/compiler_configuration.coffee
@@ -1,3 +1,5 @@
+path = Npm.require "path"
+
 # Note: same compiler can be used to compile more then one package (at least in v0.9.x)
 
 share.compiler_configuration =
@@ -10,8 +12,9 @@ share.compiler_configuration =
   project_tap_i18n_loaded_for: [] # Keeps track of the archs we've loaded project_tap_i18n for
 
   tap_i18n_input_files: []
-  registerInputFile: (compileStep) ->
-    input_file = "#{compileStep.arch}:#{compileStep._fullInputPath}"
+  registerInputFile: (input_file_obj) ->
+    full_file_path = path.join input_file_obj.getSourceRoot(), input_file_obj.getPathInPackage()
+    input_file = "#{input_file_obj.getArch()}:#{full_file_path}"
     if input_file in @tap_i18n_input_files
       # A new build cycle
       @packages = []

--- a/lib/plugin/compilers/i18n.coffee
+++ b/lib/plugin/compilers/i18n.coffee
@@ -2,17 +2,19 @@ path = Npm.require "path"
 
 compilers = share.compilers
 
-Plugin.registerSourceHandler "i18n", (compileStep) ->
-  # Starting from Meteor v1.2 registerSourceHandler doesn't
-  # accept filenames as handlers.
-  # See: https://github.com/meteor/meteor/issues/3985
-  # and: https://github.com/TAPevents/tap-i18n/issues/113
-  # Below is a workaround until we refactor for v1.2 new
-  # build plugin API.
-  file_name = _.last compileStep.inputPath.split(path.sep)
+I18nConfCompiler = compilers.I18nConfCompiler = ->
+  @processFilesForTarget = (input_files) ->
+    input_files.forEach (input_file_obj) ->
+      if input_file_obj.getBasename() is "package-tap.i18n"
+        compilers.packageTapI18n input_file_obj
 
-  if file_name == "package-tap.i18n"
-    compilers.package_tap_i18n(compileStep)
+      if input_file_obj.getBasename() is "project-tap.i18n"
+        compilers.projectTapI18n input_file_obj
+      
+      return
+        
+  return @
 
-  if file_name == "project-tap.i18n"
-    compilers.project_tap_i18n(compileStep)
+Plugin.registerCompiler 
+  extensions: ["i18n"]
+, -> new I18nConfCompiler

--- a/lib/plugin/compilers/i18n.generic_compiler.coffee
+++ b/lib/plugin/compilers/i18n.generic_compiler.coffee
@@ -4,121 +4,128 @@ helpers = share.helpers
 compilers = share.compilers
 compiler_configuration = share.compiler_configuration
 
-compilers.generic_compiler = (extension, helper) -> (compileStep) ->
-  compiler_configuration.registerInputFile(compileStep)
-  input_path = compileStep._fullInputPath
+compilers.generic_compiler = (extension, helper) -> 
+  GenericCompiler = ->
+    @processFilesForTarget = (input_files) ->
+      input_files.forEach (input_file) ->
+        compiler_configuration.registerInputFile input_file
+        
+        input_path = helpers.getFullInputPath input_file
+        language = path.basename(input_path).split(".").slice(0, -2).pop()
+        if _.isUndefined(language) or _.isEmpty(language)
+          input_file.error
+            message: "Language-tag is not specified for *.i18n.`#{extension}' file: `#{input_path}'",
+            sourcePath: input_path
+          return
 
-  language = path.basename(input_path).split(".").slice(0, -2).pop()
-  if _.isUndefined(language) or _.isEmpty(language)
-    compileStep.error
-      message: "Language-tag is not specified for *.i18n.`#{extension}' file: `#{input_path}'",
-      sourcePath: input_path
-    return
+        if not RegExp("^#{globals.langauges_tags_regex}$").test(language)
+          input_file.error
+            message: "Can't recognise '#{language}' as a language-tag: `#{input_path}'",
+            sourcePath: input_path
+          return
 
-  if not RegExp("^#{globals.langauges_tags_regex}$").test(language)
-    compileStep.error
-      message: "Can't recognise '#{language}' as a language-tag: `#{input_path}'",
-      sourcePath: input_path
-    return
+        translations = helper input_file
 
-  translations = helper input_path, compileStep
+        package_name = if helpers.isPackage(input_file) then input_file.getPackageName() else globals.project_translations_domain
+        output =
+          """
+          var _ = Package.underscore._,
+              package_name = "#{package_name}",
+              namespace = "#{package_name}";
 
-  package_name = if helpers.isPackage(compileStep) then compileStep.packageName else globals.project_translations_domain
-  output =
-    """
-    var _ = Package.underscore._,
-        package_name = "#{package_name}",
-        namespace = "#{package_name}";
+          if (package_name != "#{globals.project_translations_domain}") {
+              namespace = TAPi18n.packages[package_name].namespace;
+          }
 
-    if (package_name != "#{globals.project_translations_domain}") {
-        namespace = TAPi18n.packages[package_name].namespace;
-    }
+          """
 
-    """
+        # only for project
+        if not helpers.isPackage(input_file)
+          if /^(client|server)/.test input_file.getPathInPackage()
+            input_file.error
+              message: "Languages files should be common to the server and the client. Do not put them under /client or /server .",
+              sourcePath: input_path
+            return
 
-  # only for project
-  if not helpers.isPackage(compileStep)
-    if /^(client|server)/.test(compileStep.inputPath)
-      compileStep.error
-        message: "Languages files should be common to the server and the client. Do not put them under /client or /server .",
-        sourcePath: input_path
-      return
+          # add the language names to TAPi18n.languages_names 
+          language_name = [language, language]
+          if language_names[language]?
+            language_name = language_names[language]
 
-    # add the language names to TAPi18n.languages_names 
-    language_name = [language, language]
-    if language_names[language]?
-      language_name = language_names[language]
+          if language != globals.fallback_language
+            # the name for the fallback_language is part of the getProjectConfJs()'s output
+            output +=
+              """
+              TAPi18n.languages_names["#{language}"] = #{JSON.stringify language_name};
 
-    if language != globals.fallback_language
-      # the name for the fallback_language is part of the getProjectConfJs()'s output
-      output +=
-        """
-        TAPi18n.languages_names["#{language}"] = #{JSON.stringify language_name};
+              """
 
-        """
+          # If this is a project but project-tap.i18n haven't compiled yet add default project conf
+          # for case there is no project-tap.i18n defined in this project.
+          # Reminder: we don't require projects to have project-tap.i18n
+          if not(helpers.isDefaultProjectConfInserted(input_file)) and \
+            not(helpers.isProjectI18nLoaded(input_file))
+            output += share.getProjectConfJs(share.projectI18nObjCleaner({})) # defined in project-tap.i18n.coffee
 
-    # If this is a project but project-tap.i18n haven't compiled yet add default project conf
-    # for case there is no project-tap.i18n defined in this project.
-    # Reminder: we don't require projects to have project-tap.i18n
-    if not(helpers.isDefaultProjectConfInserted(compileStep)) and \
-       not(helpers.isProjectI18nLoaded(compileStep))
-      output += share.getProjectConfJs(share.projectI18nObjCleaner({})) # defined in project-tap.i18n.coffee
-
-      helpers.markDefaultProjectConfInserted(compileStep)
+            helpers.markDefaultProjectConfInserted(input_file)
 
 
-  # if fallback_language -> integrate, otherwise add to TAPi18n.translations if server arch.
-  if language == compiler_configuration.fallback_language
-    output +=
-      """
-      // integrate the fallback language translations 
-      translations = {};
-      translations[namespace] = #{JSON.stringify translations};
-      TAPi18n._loadLangFileObject("#{compiler_configuration.fallback_language}", translations);
+        # if fallback_language -> integrate, otherwise add to TAPi18n.translations if server arch.
+        if language == compiler_configuration.fallback_language
+          output +=
+            """
+            // integrate the fallback language translations 
+            translations = {};
+            translations[namespace] = #{JSON.stringify translations};
+            TAPi18n._loadLangFileObject("#{compiler_configuration.fallback_language}", translations);
 
-      """
+            """
 
-  if compileStep.archMatches "os"
-    if language != compiler_configuration.fallback_language
-      output +=
-        """
-        if(_.isUndefined(TAPi18n.translations["#{language}"])) {
-          TAPi18n.translations["#{language}"] = {};
-        }
+        if helpers.archMatches input_file, "os"
+          if language != compiler_configuration.fallback_language
+            output +=
+              """
+              if(_.isUndefined(TAPi18n.translations["#{language}"])) {
+                TAPi18n.translations["#{language}"] = {};
+              }
 
-        if(_.isUndefined(TAPi18n.translations["#{language}"][namespace])) {
-          TAPi18n.translations["#{language}"][namespace] = {};
-        }
+              if(_.isUndefined(TAPi18n.translations["#{language}"][namespace])) {
+                TAPi18n.translations["#{language}"][namespace] = {};
+              }
 
-        _.extend(TAPi18n.translations["#{language}"][namespace], #{JSON.stringify translations});
+              _.extend(TAPi18n.translations["#{language}"][namespace], #{JSON.stringify translations});
 
-        """
+              """
 
-    output += 
-      """
-      TAPi18n._registerServerTranslator("#{language}", namespace);
+          output += 
+            """
+            TAPi18n._registerServerTranslator("#{language}", namespace);
 
-      """
+            """
 
-  # register i18n helper for templates, only once per web arch, only for packages
-  if helpers.isPackage(compileStep)
-    if compileStep.archMatches("web") and helpers.getCompileStepArchAndPackage(compileStep) not in compiler_configuration.templates_registered_for
-      output +=
-        """
-        var package_templates = _.difference(_.keys(Template), non_package_templates);
+        # register i18n helper for templates, only once per web arch, only for packages
+        if helpers.isPackage input_file
+          if helpers.archMatches(input_file, "web") and helpers.getCompileStepArchAndPackage(input_file) not in compiler_configuration.templates_registered_for
+            output +=
+              """
+              var package_templates = _.difference(_.keys(Template), non_package_templates);
 
-        for (var i = 0; i < package_templates.length; i++) {
-          var package_template = package_templates[i];
+              for (var i = 0; i < package_templates.length; i++) {
+                var package_template = package_templates[i];
 
-          registerI18nTemplate(package_template);
-        }
+                registerI18nTemplate(package_template);
+              }
 
-        """
-      compiler_configuration.templates_registered_for.push helpers.getCompileStepArchAndPackage(compileStep)
+              """
+            compiler_configuration.templates_registered_for.push helpers.getCompileStepArchAndPackage(input_file)
 
-  output_path = compileStep.rootOutputPath + compileStep.inputPath.replace new RegExp("`#{extension}'$"), "js"
-  compileStep.addJavaScript
-    path: output_path,
-    sourcePath: input_path,
-    data: output,
-    bare: false
+        output_path = input_file.getPathInPackage().replace new RegExp("`#{extension}'$"), "js"
+        input_file.addJavaScript
+          path: output_path,
+          sourcePath: input_path,
+          data: output,
+          bare: false
+
+    return @
+  
+  return GenericCompiler

--- a/lib/plugin/compilers/i18n.json.coffee
+++ b/lib/plugin/compilers/i18n.json.coffee
@@ -1,4 +1,6 @@
 helpers = share.helpers
 compilers = share.compilers
-compilers.i18n_json = compilers.generic_compiler('json', helpers.loadJSON)
-Plugin.registerSourceHandler "i18n.json", compilers.i18n_json
+compilers.I18nJson = compilers.generic_compiler("json", helpers.loadJSON)
+Plugin.registerCompiler
+  extensions: ["i18n.json"]
+, -> new compilers.I18nJson

--- a/lib/plugin/compilers/i18n.yml.coffee
+++ b/lib/plugin/compilers/i18n.yml.coffee
@@ -1,4 +1,6 @@
 helpers = share.helpers
 compilers = share.compilers
-compilers.i18n_yml = compilers.generic_compiler('yml', helpers.loadYAML)
-Plugin.registerSourceHandler "i18n.yml", compilers.i18n_yml
+compilers.I18nYml = compilers.generic_compiler "yml", helpers.loadYAML
+Plugin.registerCompiler
+  extensions: ["i18n.yml"]
+, -> new compilers.I18nYml

--- a/lib/plugin/helpers/compile_step_helpers.coffee
+++ b/lib/plugin/helpers/compile_step_helpers.coffee
@@ -24,3 +24,11 @@ _.extend share.helpers,
     isDefaultProjectConfInserted: (input_file_obj) ->
       @getCompileStepArchAndPackage(input_file_obj) in compiler_configuration.default_project_conf_inserted_for
 
+    getFullInputPath: (input_file_obj) -> path.join input_file_obj.getSourceRoot(), input_file_obj.getPathInPackage()
+    
+    # archMatches is taken from https://github.com/meteor/meteor/blob/7da5b32d7882b510df8aa2002f891fc4e1ae1126/tools/utils/archinfo.ts#L232
+    # due to lack of exposure of meteor/tools/utils/archinfo.ts.
+    # If you find a way to use the original method, please use it and remove this one.
+    archMatches: (input_file, program) ->
+      input_file_arch = input_file.getArch()
+      return input_file_arch.substr(0, program.length) is program and (input_file_arch.length is program.length or input_file_arch.substr(program.length, 1) is ".")

--- a/lib/plugin/helpers/compile_step_helpers.coffee
+++ b/lib/plugin/helpers/compile_step_helpers.coffee
@@ -1,23 +1,26 @@
+path = Npm.require "path"
+
 compiler_configuration = share.compiler_configuration
 
 _.extend share.helpers,
-    getCompileStepArchAndPackage: (compileStep) ->
-      "#{compileStep.packageName}:#{compileStep.arch}"
+    getCompileStepArchAndPackage: (input_file_obj) ->
+      "#{input_file_obj.getPackageName()}:#{input_file_obj.getArch()}"
 
-    markAsPackage: (compileStep) ->
-      compiler_configuration.packages.push @.getCompileStepArchAndPackage(compileStep)
+    markAsPackage: (input_file_obj) ->
+      compiler_configuration.packages.push @getCompileStepArchAndPackage(input_file_obj)
 
-    isPackage: (compileStep) ->
-      @.getCompileStepArchAndPackage(compileStep) in compiler_configuration.packages
+    isPackage: (input_file_obj) ->
+      @getCompileStepArchAndPackage(input_file_obj) in compiler_configuration.packages
 
-    markProjectI18nLoaded: (compileStep) ->
-      compiler_configuration.project_tap_i18n_loaded_for.push @.getCompileStepArchAndPackage(compileStep)
+    markProjectI18nLoaded: (input_file_obj) ->
+      compiler_configuration.project_tap_i18n_loaded_for.push @getCompileStepArchAndPackage(input_file_obj)
 
-    isProjectI18nLoaded: (compileStep) ->
-      @.getCompileStepArchAndPackage(compileStep) in compiler_configuration.project_tap_i18n_loaded_for
+    isProjectI18nLoaded: (input_file_obj) ->
+      @getCompileStepArchAndPackage(input_file_obj) in compiler_configuration.project_tap_i18n_loaded_for
 
-    markDefaultProjectConfInserted: (compileStep) ->
-      compiler_configuration.default_project_conf_inserted_for.push @.getCompileStepArchAndPackage(compileStep)
+    markDefaultProjectConfInserted: (input_file_obj) ->
+      compiler_configuration.default_project_conf_inserted_for.push @getCompileStepArchAndPackage(input_file_obj)
 
-    isDefaultProjectConfInserted: (compileStep) ->
-      @.getCompileStepArchAndPackage(compileStep) in compiler_configuration.default_project_conf_inserted_for
+    isDefaultProjectConfInserted: (input_file_obj) ->
+      @getCompileStepArchAndPackage(input_file_obj) in compiler_configuration.default_project_conf_inserted_for
+

--- a/lib/plugin/helpers/load_json.coffee
+++ b/lib/plugin/helpers/load_json.coffee
@@ -1,25 +1,23 @@
-fs = Npm.require 'fs'
 JSON.minify = JSON.minify || Npm.require("node-json-minify")
+helpers = share.helpers
 
-# loads a json from file_path
+# loads a json from input_file_obj
 #
-# returns undefined if file doesn't exist null if file is empty, parsed content otherwise
+# returns undefined if file doesn't exist, null if file is empty, parsed content otherwise
 _.extend share.helpers,
-  loadJSON: (file_path, compileStep=null) ->
-    try # use try/catch to avoid the additional syscall to fs.existsSync
-      fstats = fs.statSync file_path
-    catch
+  loadJSON: (input_file_obj) ->
+    if not input_file_obj?
       return undefined
-
-    if fstats.size == 0
+      
+    if not (content_as_string = input_file_obj.getContentsAsString())?
       return null
 
     try
-      content = JSON.parse(JSON.minify(fs.readFileSync(file_path, "utf8")))
+      content = JSON.parse content_as_string
     catch error
-      if compileStep?
-        compileStep.error
-          message: "Can't load `#{file_path}' JSON",
-          sourcePath: compileStep._fullInputPath
+      full_input_path = helpers.getFullInputPath input_file_obj
+      input_file_obj.error
+        message: "Can't load `#{full_input_path}' JSON",
+        sourcePath: full_input_path
 
-      throw new Error "Can't load `#{file_path}' JSON"
+      throw new Error "Can't load `#{full_input_path}' JSON"

--- a/lib/plugin/helpers/load_yml.coffee
+++ b/lib/plugin/helpers/load_yml.coffee
@@ -1,25 +1,23 @@
-fs = Npm.require 'fs'
 YAML = Npm.require 'yamljs'
+helpers = share.helpers
 
-# loads a yml from file_path
+# loads a yml from input_file_obj
 #
-# returns undefined if file doesn't exist null if file is empty, parsed content otherwise
+# returns undefined if file doesn't exist, null if file is empty, parsed content otherwise
 _.extend share.helpers,
-  loadYAML: (file_path, compileStep=null) ->
-    try # use try/catch to avoid the additional syscall to fs.existsSync
-      fstats = fs.statSync file_path
-    catch
+  loadYAML: (input_file_obj=null) ->
+    if not input_file_obj?
       return undefined
-
-    if fstats.size == 0
+      
+    if not (content_as_string = input_file_obj.getContentsAsString())?
       return null
 
     try
-      content = YAML.load(file_path)
+      content = YAML.parse content_as_string
     catch error
-      if compileStep?
-        compileStep.error
-          message: "Can't load `#{file_path}' YAML",
-          sourcePath: compileStep._fullInputPath
+      full_input_path = helpers.getFullInputPath input_file_obj
+      input_file_obj.error
+        message: "Can't load `#{full_input_path}' YAML",
+        sourcePath: full_input_path
 
-      throw new Error "Can't load `#{file_path}' YAML"
+      throw new Error "Can't load `#{full_input_path}' YAML"

--- a/package.js
+++ b/package.js
@@ -14,6 +14,7 @@ Package.onUse(function (api) {
 
   api.use('coffeescript@2.4.1', both);
   api.use('underscore@1.0.10', both);
+  api.use('isobuild:compiler-plugin@1.0.0', both);
 
   api.use('raix:eventemitter@0.1.1', both);
   api.use('meteorspark:util@0.2.0', both);


### PR DESCRIPTION
Use the updated `registerCompiler` API from `Plugins` to avoid potential conflict with `ecmascript` package.
Also fixes an issue where i18n files inside packages are loaded without being included in `package.js`