### PR TITLE
update webapp

### DIFF
--- a/.versions
+++ b/.versions
@@ -49,5 +49,5 @@ templating-tools@1.2.0
 tracker@1.3.3
 typescript@4.9.5
 underscore@1.6.1
-webapp@1.13.8
+webapp@2.0.0
 webapp-hashing@1.1.1

--- a/package.js
+++ b/package.js
@@ -24,7 +24,7 @@ Package.onUse(function (api) {
   api.use('jquery@1.0.10', client);
   api.use('templating@1.4.0', client);
 
-  api.use("webapp", server);
+  api.use("webapp@2.0.0", server);
 
   // load TAPi18n
   api.addFiles('lib/globals.js', both);


### PR DESCRIPTION
For compatiblity with meteor >3.0.1 we need to update the webapp package. As discussed in the issue, I open the PR pointing out where I pinned the webapp version. This worked in my local environment. I couldn't test it otherwise.

Best M